### PR TITLE
refactor: Redis 이벤트 큐 유저 식별자를 username에서 userId로 변경

### DIFF
--- a/src/main/java/org/example/ticketing/domain/event/controller/EventController.java
+++ b/src/main/java/org/example/ticketing/domain/event/controller/EventController.java
@@ -36,7 +36,7 @@ public class EventController {
       @PathVariable Long id,
       @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal
   ) {
-    return eventQueueService.getQueueStatus(id, customUserPrincipal.username())
+    return eventQueueService.getQueueStatus(id, customUserPrincipal.userId())
         .flatMap(status -> {
           if (!status.isAvailable()) {
             return Mono.error(new QueueWaitingException(status.rank()));
@@ -44,7 +44,7 @@ public class EventController {
 
           return eventService.getEventDetail(id)
               .flatMap(response ->
-                  eventQueueService.deleteQueue(response.id(), customUserPrincipal.username())
+                  eventQueueService.deleteQueue(response.id(), customUserPrincipal.userId())
                       .thenReturn(ResponseEntity.ok(ApiResponse.success(response))));
         });
   }

--- a/src/main/java/org/example/ticketing/domain/event/controller/EventQueueController.java
+++ b/src/main/java/org/example/ticketing/domain/event/controller/EventQueueController.java
@@ -21,7 +21,7 @@ public class EventQueueController {
       @PathVariable Long eventId,
       @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal
   ) {
-    return eventQueueService.registerQueue(eventId, customUserPrincipal.username())
+    return eventQueueService.registerQueue(eventId, customUserPrincipal.userId())
         .map(rank -> ResponseEntity.ok(ApiResponse.success(rank)));
   }
 
@@ -30,7 +30,7 @@ public class EventQueueController {
       @PathVariable Long eventId,
       @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal
   ) {
-    return eventQueueService.getQueueStatus(eventId, customUserPrincipal.username())
+    return eventQueueService.getQueueStatus(eventId, customUserPrincipal.userId())
         .map(status -> ResponseEntity.ok(ApiResponse.success(status)));
   }
 }

--- a/src/main/java/org/example/ticketing/domain/event/service/EventQueueService.java
+++ b/src/main/java/org/example/ticketing/domain/event/service/EventQueueService.java
@@ -13,39 +13,40 @@ import java.time.Instant;
 public class EventQueueService {
   private final ReactiveStringRedisTemplate redis;
 
-  private final static String QUEUE_KEY = "event:queue";
+  private final static String QUEUE_KEY = "event:queue:";
   private final static long ALLOWED_USER_COUNT = 1;
 
-  public Mono<Long> registerQueue(Long eventId, String username) {
+  public Mono<Long> registerQueue(Long eventId, Long userId) {
     String key = QUEUE_KEY + eventId;
     long timestamp = Instant.now().toEpochMilli();
+    String userIdStr = String.valueOf(userId);
 
     return redis.opsForZSet()
-        .add(key, username, timestamp)
-        .then(getRank(eventId, username));
+        .add(key, userIdStr, timestamp)
+        .then(getRank(eventId, userId));
   }
 
-  public Mono<Long> getRank(Long eventId, String username) {
+  public Mono<Long> getRank(Long eventId, Long userId) {
     String key = QUEUE_KEY + eventId;
+    String userIdStr = String.valueOf(userId);
 
     return redis.opsForZSet()
-        .rank(key, username)
+        .rank(key, userIdStr)
         .map(rank -> rank + 1)
         .defaultIfEmpty(0L);
   }
 
-  public Mono<QueueStatusDto> getQueueStatus(Long eventId, String username) {
-    String key = QUEUE_KEY + eventId;
-
-    return getRank(eventId, username)
+  public Mono<QueueStatusDto> getQueueStatus(Long eventId, Long userId) {
+    return getRank(eventId, userId)
         .map(rank -> new QueueStatusDto(rank, rank > 0 && rank <= ALLOWED_USER_COUNT));
   }
 
-  public Mono<Boolean> deleteQueue(Long eventId, String username) {
+  public Mono<Boolean> deleteQueue(Long eventId, Long userId) {
     String key = QUEUE_KEY + eventId;
+    String userIdStr = String.valueOf(userId);
 
     return redis.opsForZSet()
-        .remove(key, username)
+        .remove(key, userIdStr)
         .map(removed -> removed > 0);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated queue management system to use user IDs instead of usernames for user identification during queue registration and status tracking operations. This improves consistency in how users are identified across the queue service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->