### PR TITLE
fix: 대기열 중복 등록 시 기존 순위가 덮어씌워지는 문제 해결

### DIFF
--- a/src/main/java/org/example/ticketing/domain/Queue/controller/EventQueueController.java
+++ b/src/main/java/org/example/ticketing/domain/Queue/controller/EventQueueController.java
@@ -17,10 +17,6 @@ public class EventQueueController {
 
   private final EventQueueService eventQueueService;
 
-  /**
-   * 대기열 등록 (REST - 최초 1회)
-   * 등록 후 WebSocket ws://host/ws/queue/{eventId}?userId={userId} 로 연결하여 실시간 순위 수신
-   */
   @PostMapping("{eventId}")
   public Mono<ResponseEntity<ApiResponse<Long>>> registerQueue(
       @PathVariable Long eventId,
@@ -30,10 +26,6 @@ public class EventQueueController {
         .map(rank -> ResponseEntity.ok(ApiResponse.success(rank)));
   }
 
-  /**
-   * 대기열 상태 단건 조회 (REST - 폴링 방식 필요 시 유지, WebSocket 사용 시 선택적)
-   * WebSocket 연결이 어려운 환경을 위한 fallback용
-   */
   @GetMapping("{eventId}")
   public Mono<ResponseEntity<ApiResponse<QueueStatusDto>>> checkQueueStatus(
       @PathVariable Long eventId,

--- a/src/main/java/org/example/ticketing/domain/Queue/service/EventQueueService.java
+++ b/src/main/java/org/example/ticketing/domain/Queue/service/EventQueueService.java
@@ -3,10 +3,11 @@ package org.example.ticketing.domain.Queue.service;
 import lombok.RequiredArgsConstructor;
 import org.example.ticketing.domain.Queue.dto.QueueStatusDto;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -16,34 +17,31 @@ public class EventQueueService {
 
   private static final String QUEUE_KEY = "event:queue:";
   private static final long ALLOWED_USER_COUNT = 100;
+  private static final Duration QUEUE_TTL = Duration.ofHours(2);
+
+  private String queueKey(Long eventId) {
+    return QUEUE_KEY + eventId;
+  }
 
   public Mono<Long> registerQueue(Long eventId, Long userId) {
-    String key = QUEUE_KEY + eventId;
-    String userKey = key + ":users";
+    String key = queueKey(eventId);
     String userIdStr = String.valueOf(userId);
-    String seqKey = key + ":seq";
+    double score = System.nanoTime();
 
-    return redis.opsForSet()
-        .add(userKey, userIdStr)
-        .flatMap(added -> {
-          if (added == 0) {
-            return redis.opsForZSet()
-                .rank(key, userIdStr)
-                .map(rank -> rank + 1);
-          }
-
-          return redis.opsForValue()
-              .increment(seqKey)
-              .flatMap(seq -> redis.opsForZSet()
-                  .add(key, userIdStr, seq)
-                  .then(redis.opsForZSet()
-                      .rank(key, userIdStr))
-                      .map(rank -> rank + 1));
-        });
+    return redis.opsForZSet()
+        .rank(key, userIdStr)
+        .switchIfEmpty(
+            redis.opsForZSet()
+                .add(key, userIdStr, score)
+                .then(redis.expire(key, QUEUE_TTL))
+                .then(redis.opsForZSet().rank(key, userIdStr))
+        )
+        .map(rank -> rank + 1)
+        .defaultIfEmpty(0L);
   }
 
   public Mono<Long> getRank(Long eventId, Long userId) {
-    String key = QUEUE_KEY + eventId;
+    String key = queueKey(eventId);
     String userIdStr = String.valueOf(userId);
 
     return redis.opsForZSet()
@@ -57,16 +55,17 @@ public class EventQueueService {
         .map(rank -> new QueueStatusDto(rank, rank > 0 && rank <= ALLOWED_USER_COUNT));
   }
 
+  public Mono<Boolean> validateEntry(Long eventId, Long userId) {
+    return getRank(eventId, userId)
+        .map(rank -> rank > 0 && rank <= ALLOWED_USER_COUNT);
+  }
+
   public Mono<Boolean> deleteQueue(Long eventId, Long userId) {
-    String key = QUEUE_KEY + eventId;
-    String userKey = key + ":users";
+    String key = queueKey(eventId);
     String userIdStr = String.valueOf(userId);
 
     return redis.opsForZSet()
         .remove(key, userIdStr)
-        .flatMap(removed ->
-            redis.opsForSet()
-                .remove(userKey, userIdStr)
-                .thenReturn(removed > 0));
+        .map(removed -> removed > 0);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to validate whether a user is within the allowed entry range for an event.
  * Queue entries now expire after 2 hours, so stale registrations are automatically cleared.

* **Bug Fixes**
  * Registration preserves existing users' positions and returns their current rank without altering standings.
  * Queue status and rank reporting remain consistent with the updated registration flow.

* **Chores**
  * Increased allowed users per event from 1 to 100 to support larger queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->